### PR TITLE
Try fix broken page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <title>Steve Nguyen</title>
-  <base href="/">
+  <base href="/resume/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <script src="https://kit.fontawesome.com/a41a8741eb.js" crossorigin="anonymous"></script>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "resume",
   "version": "0.0.0",
+  "homepage": "https://stevenguyen18595.github.io/resume/",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --base-href \"/resume/\"",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
The GitHub page couldn't find Javascript assets because it was trying to resolve resources in the root folder,
However, resources are in the `/resume`  folder

Eg:
https://stevenguyen18595.github.io/scripts.74e37104b8240f0c.js will return 404
but
https://stevenguyen18595.github.io/resume/scripts.74e37104b8240f0c.js will return the correct file

**Changes**
Modify the build script to replace base href when build the project